### PR TITLE
[RFC] Use underline highlight instead of reversed highlights for white spaces.

### DIFF
--- a/autoload/shot_f.vim
+++ b/autoload/shot_f.vim
@@ -79,7 +79,7 @@ function! s:highlight_one_of_each_char(ft, forward, count)
     let cur_char = line[cur_col]
     let char_dict[cur_char] = get(char_dict, cur_char, 0) + 1
     if char_dict[cur_char] == a:count
-      call matchadd(cur_char =~ '[[:blank:]]' ? 'ShotFBlank' : 'ShotFGraph', printf('\%%%dl\%%%dc', lnum, cur_col+1))
+      call matchadd('ShotFChar', printf('\%%%dl\%%%dc', lnum, cur_col+1))
     endif
   endfor
 
@@ -87,19 +87,17 @@ function! s:highlight_one_of_each_char(ft, forward, count)
 endfunction
 
 function! s:disable_highlight()
-  for h in filter(getmatches(), 'v:val.group ==# "ShotFGraph" || v:val.group ==# "ShotFBlank"')
+  for h in filter(getmatches(), 'v:val.group ==# "ShotFChar"')
     call matchdelete(h.id)
   endfor
 endfunction
 
 augroup plugin-shot-f-highlight
   autocmd!
-  autocmd ColorScheme * highlight default ShotFGraph ctermfg=red ctermbg=NONE cterm=bold guifg=red guibg=NONE gui=bold
-  autocmd ColorScheme * highlight default ShotFBlank ctermfg=NONE ctermbg=red cterm=NONE guifg=NONE guibg=red gui=NONE
+  autocmd ColorScheme * highlight default ShotFChar ctermfg=red ctermbg=NONE cterm=bold,underline guifg=red guibg=NONE gui=bold,underline
 augroup END
 
-highlight default ShotFGraph ctermfg=red ctermbg=NONE cterm=bold guifg=red guibg=NONE gui=bold
-highlight default ShotFBlank ctermfg=NONE ctermbg=red cterm=bold guifg=NONE guibg=red gui=bold
+highlight default ShotFChar ctermfg=red ctermbg=NONE cterm=bold,underline guifg=red guibg=NONE gui=bold,underline
 
 "}}}
 


### PR DESCRIPTION
現在の shot-f のハイライトは，
1. 通常は赤文字ボールド
2. ホワイトスペースは反転して赤色ハイライト

というふうになっていますが，反転した半角スペースのハイライトはカーソルと見間違えやすいと思います．そこで，アンダーラインをハイライトに使ってみました．これにより，空白もハイライトされているのが分かると思う上，カーソルと見間違うことはないと思うのですが，どうでしょうか？
- 元の状態（行頭にカーソルがある）

![s0](https://dl.dropboxusercontent.com/u/2753138/shot-f-0.png)
- 現在の shot-f のハイライト

![s1](https://dl.dropboxusercontent.com/u/2753138/shot-f-1.png)
- このプルリクエストで変更したハイライト

![s2](https://dl.dropboxusercontent.com/u/2753138/shot-f-2.png)
