### PR TITLE
specify a register for operator-pending mode

### DIFF
--- a/autoload/shot_f.vim
+++ b/autoload/shot_f.vim
@@ -80,7 +80,7 @@ function! s:shot_f(ft)
     elseif mode ==? 'v' || mode ==# "\<C-v>"
       return "\<Esc>" . 'gv' . cnt . a:ft . c
     elseif mode ==# 'no'
-      return "\<Esc>" . cnt . v:operator . a:ft . c
+      return "\<Esc>" . '"' . v:register . cnt . v:operator . a:ft . c
     endif
   finally
     call s:finalize()


### PR DESCRIPTION
オペレータ待機モードでレジスタ指定が無視されていたので考慮するように修正しました。