### PR TITLE
Do not use bang

### DIFF
--- a/autoload/shot_f.vim
+++ b/autoload/shot_f.vim
@@ -128,7 +128,7 @@ function! s:highlight_one_of_each_char(forward, count)
     let s:max_count = char_dict[cur_char] > s:max_count ? char_dict[cur_char] : s:max_count
   endfor
 
-  redraw!
+  redraw
 endfunction
 
 function! s:disable_highlight()


### PR DESCRIPTION
I removed a exclamation mark when using "redraw".
Because when ! is included the screen is cleared first. But I don't like flickering screen.

This setting working correctly on my GVim on Windows. But I have no other environments, sorry.