### PR TITLE
ignore multibyte character

### DIFF
--- a/autoload/shot_f.vim
+++ b/autoload/shot_f.vim
@@ -122,7 +122,7 @@ function! s:highlight_one_of_each_char(forward, count)
   for cur_col in list
     let cur_char = line[cur_col]
     let char_dict[cur_char] = get(char_dict, cur_char, 0) + 1
-    if char_dict[cur_char] == a:count
+    if cur_char =~ '[\x01-\x7E]' && char_dict[cur_char] == a:count
       call matchadd(cur_char =~ '[[:blank:]]' ? 'ShotFBlank' : 'ShotFGraph', printf('\%%%dl\%%%dc', lnum, cur_col+1))
     endif
     let s:max_count = char_dict[cur_char] > s:max_count ? char_dict[cur_char] : s:max_count


### PR DESCRIPTION
いつもお世話になっております！
fでマルチバイト文字にジャンプすることは無いと思いましたので、ハイライト対象から除外しました。