### PR TITLE
Do not use bang

### DIFF
--- a/autoload/shot_f.vim
+++ b/autoload/shot_f.vim
@@ -128,7 +128,7 @@ function! s:highlight_one_of_each_char(forward, count)
     let s:max_count = char_dict[cur_char] > s:max_count ? char_dict[cur_char] : s:max_count
   endfor
 
-  redraw!
+  redraw
 endfunction
 
 function! s:disable_highlight()


### PR DESCRIPTION
いつもお世話になっております！
redraw!は画面を消去してから再描画するため、私の環境では画面が一瞬フラッシュしてしまいます。
精神衛生上良くないので、redrawを使用するようにしました。

* Environment Information
 * OS: Windows 7 64-bit
 * Vim version: GVim 7.4.1016