### PR TITLE
Do not return unnecessary esc

### DIFF
--- a/autoload/shot_f.vim
+++ b/autoload/shot_f.vim
@@ -76,7 +76,10 @@ function! s:shot_f(ft)
     endwhile
 
     if mode ==# 'n'
-      return "\<Esc>" . cnt . a:ft . c
+      if v:count >= 1
+        return "\<Esc>" . cnt . a:ft . c
+      endif
+      return cnt . a:ft . c
     elseif mode ==? 'v' || mode ==# "\<C-v>"
       return "\<Esc>" . 'gv' . cnt . a:ft . c
     elseif mode ==# 'no'


### PR DESCRIPTION
いつもお世話になっております！
belloff=escしていない環境でbellが鳴ってしまっていたので、不要な<Esc>を返さないようにしました。
