### PR TITLE
Make highlight style configurable

### DIFF
--- a/autoload/shot_f.vim
+++ b/autoload/shot_f.vim
@@ -159,15 +159,24 @@ function! s:unexpected_character(c)
   return a:c ==# "\x80\xfd`"
 endfunction
 
+function! s:register_highlights()
+  if !exists('g:shot_f_highlight_graph')
+    let g:shot_f_highlight_graph = 'ctermfg=red ctermbg=NONE cterm=bold guifg=red guibg=NONE gui=bold'
+  endif
+  if !exists('g:shot_f_highlight_blank')
+    let g:shot_f_highlight_blank = 'ctermfg=NONE ctermbg=red cterm=NONE guifg=NONE guibg=red gui=NONE'
+  endif
+  execute 'highlight default ShotFGraph ' . g:shot_f_highlight_graph
+  execute 'highlight default ShotFBlank ' . g:shot_f_highlight_blank
+  highlight link ShotFCursor Cursor
+endfunction
+
 augroup plugin-shot-f-highlight
   autocmd!
-  autocmd ColorScheme * highlight default ShotFGraph ctermfg=red ctermbg=NONE cterm=bold guifg=red guibg=NONE gui=bold
-  autocmd ColorScheme * highlight default ShotFBlank ctermfg=NONE ctermbg=red cterm=NONE guifg=NONE guibg=red gui=NONE
+  autocmd ColorScheme * call <sid>register_highlights()
 augroup END
 
-highlight default ShotFGraph ctermfg=red ctermbg=NONE cterm=bold guifg=red guibg=NONE gui=bold
-highlight default ShotFBlank ctermfg=NONE ctermbg=red cterm=bold guifg=NONE guibg=red gui=bold
-highlight link ShotFCursor Cursor
+call s:register_highlights()
 
 "}}}
 

--- a/doc/shot_f.txt
+++ b/doc/shot_f.txt
@@ -83,6 +83,26 @@ g:shot_f_decrement_count_key			*g:shot_f_decrement_count_key*
   by |[count]|.
 
 
+g:shot_f_highlight_graph			*g:shot_f_highlight_graph*
+
+  Type: |String|
+  Default: `"ctermfg=red ctermbg=NONE cterm=bold guifg=red guibg=NONE gui=bold"`
+
+  Defines the highlight style for graphical characters.
+
+  See |highlight-args| for the {key}={arg} arguments.
+
+
+g:shot_f_highlight_blank			*g:shot_f_highlight_blank*
+
+  Type: |String|
+  Default: `"ctermfg=NONE ctermbg=red cterm=NONE guifg=NONE guibg=red gui=NONE"`
+
+  Defines the highlight style for blank characters (space and tab).
+
+  See |highlight-args| for the {key}={arg} arguments.
+
+
 ==============================================================================
 EXAMPLES					*shot-f-examples*
 

--- a/doc/shot_f.txt
+++ b/doc/shot_f.txt
@@ -53,62 +53,79 @@ INTERFACE					*shot-f-interface*
 ------------------------------------------------------------------------------
 MAPPINGS					*shot-f-mappings*
 
+These mappings are defined in Normal mode, Visual mode
+and Operator-pending mode:
+
 <Plug>(shot-f-f)				*<Plug>(shot-f-f)*
 <Plug>(shot-f-F)				*<Plug>(shot-f-F)*
 <Plug>(shot-f-t)				*<Plug>(shot-f-t)*
 <Plug>(shot-f-T)				*<Plug>(shot-f-T)*
-			These mappings are defined in Normal mode, Visual mode
-			and Operator-pending mode.
 
 
 ------------------------------------------------------------------------------
 VARIABLES					*shot-f-variables*
 
-g:shot_f_increment_count_key   (default: "\<CR>")
-			If you type this key after executing mapping key,
-			you can increment |[count]| of mapping key
-g:shot_f_decrement_count_key   (default: "\<BS>")
-			If you type this key after executing mapping key,
-			you can decrement [|count]| of mapping key
+g:shot_f_increment_count_key			*g:shot_f_increment_count_key*
+
+  Type: |String|
+  Default: `"\<CR>"`
+
+  Typing this key after executing the mapping key increments the mapping key
+  by |[count]|.
+
+
+g:shot_f_decrement_count_key			*g:shot_f_decrement_count_key*
+
+  Type: |String|
+  Default: `"\<BS>"`
+
+  Typing this key after executing the mapping key decrements the mapping key
+  by |[count]|.
 
 
 ==============================================================================
 EXAMPLES					*shot-f-examples*
 
-" default mapping is following
-nmap f  <Plug>(shot-f-f)
-nmap F  <Plug>(shot-f-F)
-nmap t  <Plug>(shot-f-t)
-nmap T  <Plug>(shot-f-T)
-xmap f  <Plug>(shot-f-f)
-xmap F  <Plug>(shot-f-F)
-xmap t  <Plug>(shot-f-t)
-xmap T  <Plug>(shot-f-T)
-omap f  <Plug>(shot-f-f)
-omap F  <Plug>(shot-f-F)
-omap t  <Plug>(shot-f-t)
-omap T  <Plug>(shot-f-T)
+The default mappings are as follows:
+>
+  nmap f  <Plug>(shot-f-f)
+  nmap F  <Plug>(shot-f-F)
+  nmap t  <Plug>(shot-f-t)
+  nmap T  <Plug>(shot-f-T)
+  xmap f  <Plug>(shot-f-f)
+  xmap F  <Plug>(shot-f-F)
+  xmap t  <Plug>(shot-f-t)
+  xmap T  <Plug>(shot-f-T)
+  omap f  <Plug>(shot-f-f)
+  omap F  <Plug>(shot-f-F)
+  omap t  <Plug>(shot-f-t)
+  omap T  <Plug>(shot-f-T)
+<
 
-" If you want change mapping, you can write following settings in your vimrc
-let g:shot_f_no_default_key_mappings = 1
-nmap ,f  <Plug>(shot-f-f)
-nmap ,F  <Plug>(shot-f-F)
-nmap ,t  <Plug>(shot-f-t)
-nmap ,T  <Plug>(shot-f-T)
-xmap ,f  <Plug>(shot-f-f)
-xmap ,F  <Plug>(shot-f-F)
-xmap ,t  <Plug>(shot-f-t)
-xmap ,T  <Plug>(shot-f-T)
-omap ,f  <Plug>(shot-f-f)
-omap ,F  <Plug>(shot-f-F)
-omap ,t  <Plug>(shot-f-t)
-omap ,T  <Plug>(shot-f-T)
+If you want to change the mappings, you can use the following settings in
+your vimrc:
+>
+  let g:shot_f_no_default_key_mappings = 1
+  nmap ,f  <Plug>(shot-f-f)
+  nmap ,F  <Plug>(shot-f-F)
+  nmap ,t  <Plug>(shot-f-t)
+  nmap ,T  <Plug>(shot-f-T)
+  xmap ,f  <Plug>(shot-f-f)
+  xmap ,F  <Plug>(shot-f-F)
+  xmap ,t  <Plug>(shot-f-t)
+  xmap ,T  <Plug>(shot-f-T)
+  omap ,f  <Plug>(shot-f-f)
+  omap ,F  <Plug>(shot-f-F)
+  omap ,t  <Plug>(shot-f-t)
+  omap ,T  <Plug>(shot-f-T)
+<
 
-" If you want change key for incrementing or decrementing count,
-" you can write following settings in your vimrc
-let g:shot_f_increment_count_key = "\<C-k>"
-let g:shot_f_decrement_count_key = "\<C-j>"
-
+If you want to change the key for incrementing or decrementing count, you can
+use the following settings in your vimrc:
+>
+  let g:shot_f_increment_count_key = "\<C-k>"
+  let g:shot_f_decrement_count_key = "\<C-j>"
+<
 
 ==============================================================================
 BUGS						*shot-f-bugs*


### PR DESCRIPTION
Use g:shot_f_highlight_graph and g:shot_f_highlight_blank to configure the highlight style.

These variables accept an argument that will be passed to vim's highlight function; see vim's help for |highlight-args| for details.

I additionally cleaned up the help file a bit, fixing up some of the grammar, and adjusting the layout for the variables section to make the new longer default values fit onto a single line.